### PR TITLE
feat: Helm Logo Support for Programming Language Icons

### DIFF
--- a/charts/tum-theia-cloud/templates/landing-page-config-map.yaml
+++ b/charts/tum-theia-cloud/templates/landing-page-config-map.yaml
@@ -1,0 +1,49 @@
+{{- $logoFileExtension :=  tpl (index .Values "theia-cloud" "landingPage" "logoFileExtension" | toString) . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: landing-page-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.js: |
+    window.theiaCloudConfig = {
+      appId: "{{ tpl (index .Values "theia-cloud" "app" "id" | toString) . }}",
+      appName: "{{ tpl (index .Values "theia-cloud" "app" "name" | toString) . }}",
+      useEphemeralStorage: {{ tpl (index .Values "theia-cloud" "landingPage" "ephemeralStorage" | toString) . }},
+      useKeycloak: {{ tpl (index .Values "theia-cloud" "keycloak" "enable" | toString) . }},
+      keycloakAuthUrl: "{{ tpl (index .Values "theia-cloud" "keycloak" "authUrl" | toString) . }}",
+      keycloakRealm: "{{ tpl (index .Values "theia-cloud" "keycloak" "realm" | toString) . }}",
+      keycloakClientId: "{{ tpl (index .Values "theia-cloud" "keycloak" "clientId" | toString) . }}",
+      {{- if .Values.hosts.usePaths }}
+      serviceUrl: "{{ tpl (index .Values "theia-cloud" "service" "protocol" | toString) . }}://{{ tpl (.Values.hosts.configuration.baseHost | toString) . }}/{{ tpl (.Values.hosts.configuration.service | toString) . }}",
+      {{- else }}
+      serviceUrl: "{{ tpl (index .Values "theia-cloud" "service" "protocol" | toString) . }}://{{ tpl (.Values.hosts.configuration.service | toString) . }}.{{ tpl (.Values.hosts.configuration.baseHost | toString) . }}",
+      {{- end }}
+      appDefinition: "{{ tpl (index .Values "theia-cloud" "landingPage" "appDefinition" | toString) . }}",
+      additionalApps: [
+        {{- range $key, $val := (index .Values "theia-cloud" "landingPage" "additionalApps") }}
+        {
+          appId: {{ $key | quote}},
+          appName: {{ $val.label | quote }},
+          {{- if $val.icon }}
+          logo: {{ $val.icon | quote }},
+          {{- end }}
+        },
+        {{- end }}
+      ],
+      logoFileExtension: "{{ $logoFileExtension }}",
+      disableInfo: {{ tpl (index .Values "theia-cloud" "landingPage" "disableInfo" | toString) . }},
+      {{- if (index .Values "theia-cloud" "landingPage" "infoText") }}
+      infoText: "{{ tpl (index .Values "theia-cloud" "landingPage" "infoText" | toString) . }}",
+      {{- end }}
+      {{- if (index .Values "theia-cloud" "landingPage" "infoTitle") }}
+      infoTitle: "{{ tpl (index .Values "theia-cloud" "landingPage" "infoTitle" | toString) . }}",
+      {{- end }}
+      {{- if (index .Values "theia-cloud" "landingPage" "loadingText") }}
+      loadingText: "{{ tpl (index .Values "theia-cloud" "landingPage" "loadingText" | toString) . }}",
+      {{- end }}
+    };
+binaryData:
+  {{- if (index .Values "theia-cloud" "landingPage" "logoData") }}
+  {{ printf "logo.%s: " $logoFileExtension }}{{ (index .Values "theia-cloud" "landingPage" "logoData") }}
+  {{- end }}


### PR DESCRIPTION
## 🎯 Helm Logo Support for Programming Language Icons

This PR adds Helm template support to display programming language icons in the landing page.

### 🎨 Features Added:
- **Custom Helm Template**: Created override for landing-page-config-map.yaml
- **Logo Mapping**: Fixed mapping from values file icon field to config.js logo property  
- **Programming Language Icons**: Enables proper display of Java, C, JavaScript, Python, Rust, and OCaml logos
- **Chart Compatibility**: Maintains compatibility with existing Helm chart structure

### 🔧 Technical Changes:
- Added charts/tum-theia-cloud/templates/landing-page-config-map.yaml override
- Implemented proper Helm templating for logo configuration
- Ensured icons are correctly passed to the landing page application

### 🎯 Impact:
- **Visual Enhancement**: Programming language icons now display correctly
- **User Experience**: Better visual identification of available programming environments  
- **Maintainability**: Clean separation between chart configuration and application logic
- **Flexibility**: Easy to add new programming languages with icons

Ready for deployment! 🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces a configurable landing page via ConfigMap, exposing app ID/name, storage options, authentication settings, and a conditionally formed service URL (path- or host-based).
  * Supports displaying an app definition and a list of additional apps.
  * Adds optional info title/text and loading text that appear when configured.
  * Enables embedding a custom logo (binary) with automatic file extension handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->