### PR TITLE
Fix namespace conflicts when cluster-wide resources are installed mul…

### DIFF
--- a/.github/workflows/deploy-theia.yml
+++ b/.github/workflows/deploy-theia.yml
@@ -84,7 +84,7 @@ jobs:
           kubectl config get-contexts
           kubectl get nodes
 
-      # Step 4: Install Theia Cloud base components and CRDs
+      # Step 4: Install Theia Cloud base components, CRDs, and cluster-wide monitoring
       # These are prerequisites from the upstream Theia Cloud Helm repository
       - name: Setup Helm dependencies
         env:
@@ -103,9 +103,12 @@ jobs:
           # Install Custom Resource Definitions (CRDs) for Theia Cloud
           helm upgrade theia-cloud-crds theia-cloud-repo/theia-cloud-crds --install -f ${{ vars.HELM_VALUES_PATH }}/theia-crds-helm-values.yml
 
+          # Install cluster-wide monitoring (PodMonitors + Grafana Dashboards)
+          # This is installed once per cluster, not per environment
+          helm upgrade theia-monitoring ./charts/theia-monitoring --install
+
       # Step 5: Install the main Theia Cloud application with environment-specific configuration
-      # This includes the operator, service, certificates, app definitions, and monitoring (PodMonitors + Grafana dashboards)
-      # Monitoring resources are installed into Rancher's native monitoring stack (cattle-monitoring-system + cattle-dashboards)
+      # This includes the operator, service, certificates, and app definitions
       - name: Install Theia Cloud in namespace ${{ vars.NAMESPACE }}
         env:
           KUBECONFIG: ${{ github.workspace }}/kubeconfig

--- a/charts/theia-cloud-combined/values.yaml
+++ b/charts/theia-cloud-combined/values.yaml
@@ -124,21 +124,3 @@ theia-appdefinitions:
   #     image: ghcr.io/ls1intum/theia/python
   #     imageTag: v2.0.0
 
-# Monitoring configuration for Rancher native monitoring stack
-monitoring:
-  # -- Enable monitoring resources (PodMonitors and Grafana Dashboards)
-  enabled: true
-  
-  # -- Namespace where PodMonitors should be created (must match where Prometheus can discover them)
-  namespace: cattle-monitoring-system
-  
-  # -- Namespace where Grafana dashboards should be created (must have grafana_dashboard: "1" label discovery)
-  dashboardNamespace: cattle-dashboards
-  
-  # -- List of namespaces to monitor for Theia Cloud service pods
-  # Should be overridden in deployment-specific values.yaml files
-  targetNamespaces: []
-  
-  # -- List of namespaces to monitor for Theia session pods
-  # Should be overridden in deployment-specific values.yaml files
-  sessionNamespaces: []

--- a/charts/theia-monitoring/Chart.yaml
+++ b/charts/theia-monitoring/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: theia-monitoring
+description: Cluster-wide monitoring resources for Theia Cloud (PodMonitors + Grafana Dashboards)
+version: 0.1.0
+appVersion: 1.0.0

--- a/charts/theia-monitoring/templates/dashboard-session-startup.yaml
+++ b/charts/theia-monitoring/templates/dashboard-session-startup.yaml
@@ -1,11 +1,10 @@
-{{- if .Values.monitoring.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
     grafana_dashboard: "1"
   name: theia-cloud-dashboard-session-startup
-  namespace: {{ .Values.monitoring.dashboardNamespace }}
+  namespace: {{ .Values.dashboardNamespace }}
 data:
   session-startup.json: |-
     {
@@ -315,4 +314,4 @@ data:
       "version": 8,
       "weekStart": ""
     }
-{{- end }}
+

--- a/charts/theia-monitoring/templates/dashboard-theiacloud.yaml
+++ b/charts/theia-monitoring/templates/dashboard-theiacloud.yaml
@@ -1,11 +1,10 @@
-{{- if .Values.monitoring.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
     grafana_dashboard: "1"
   name: theia-cloud-dashboard-overview
-  namespace: {{ .Values.monitoring.dashboardNamespace }}
+  namespace: {{ .Values.dashboardNamespace }}
 data:
   theiacloud.json: |-
     {
@@ -616,4 +615,4 @@ data:
       "version": 7,
       "weekStart": ""
     }
-{{- end }}
+

--- a/charts/theia-monitoring/templates/podmonitor-service.yaml
+++ b/charts/theia-monitoring/templates/podmonitor-service.yaml
@@ -1,20 +1,19 @@
-{{- if .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: theia-cloud-service
-  namespace: {{ .Values.monitoring.namespace }}
+  namespace: {{ .Values.namespace }}
 spec:
   selector:
     matchLabels:
       app: service
   namespaceSelector:
     matchNames:
-      {{- range .Values.monitoring.targetNamespaces }}
+      {{- range .Values.targetNamespaces }}
       - {{ . }}
       {{- end }}
   podMetricsEndpoints:
     - port: http
       interval: 15s
       path: /q/metrics
-{{- end }}
+

--- a/charts/theia-monitoring/templates/podmonitor-sessions.yaml
+++ b/charts/theia-monitoring/templates/podmonitor-sessions.yaml
@@ -1,9 +1,8 @@
-{{- if .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: theia-cloud-sessions
-  namespace: {{ .Values.monitoring.namespace }}
+  namespace: {{ .Values.namespace }}
 spec:
   selector:
     matchExpressions:
@@ -16,11 +15,10 @@ spec:
           - service
   namespaceSelector:
     matchNames:
-      {{- range .Values.monitoring.sessionNamespaces }}
+      {{- range .Values.sessionNamespaces }}
       - {{ . }}
       {{- end }}
   podMetricsEndpoints:
     - port: application
       interval: 15s
-{{- end }}
 

--- a/charts/theia-monitoring/values.yaml
+++ b/charts/theia-monitoring/values.yaml
@@ -1,0 +1,25 @@
+# Monitoring configuration for Rancher native monitoring stack
+# This chart is installed ONCE per cluster, not per environment
+
+# -- Namespace where PodMonitors should be created (must match where Prometheus can discover them)
+namespace: cattle-monitoring-system
+
+# -- Namespace where Grafana dashboards should be created (must have grafana_dashboard: "1" label discovery)
+dashboardNamespace: cattle-dashboards
+
+# -- List of namespaces to monitor for Theia Cloud service pods (operator, service, landing-page)
+targetNamespaces:
+  - theia
+  - theia-staging
+  - test1
+  - test2
+  - test3
+
+# -- List of namespaces to monitor for Theia session pods
+sessionNamespaces:
+  - theia
+  - theia-staging
+  - test1
+  - test2
+  - test3
+


### PR DESCRIPTION
# Separate monitoring into standalone Helm chart

## Problem

Deploying multiple Theia Cloud environments (test1, staging, prod) to the same cluster caused Helm ownership conflicts:
ConfigMap "theia-cloud-dashboard-session-startup" exists and cannot be imported: `key "meta.helm.sh/release-namespace" must equal "test1": current value is "theia-staging"`
Monitoring resources (PodMonitors, Grafana dashboards) are cluster-wide but were being installed per-environment.


## Solution
Created new `theia-monitoring` chart for cluster-wide resources
Removed monitoring templates from `theia-cloud-combined`
Install `theia-monitoring` once alongside `theia-cloud-base` and `theia-cloud-crds`