### PR TITLE
Explicitely set service auth token

### DIFF
--- a/charts/theia-cloud-combined/values.yaml
+++ b/charts/theia-cloud-combined/values.yaml
@@ -44,6 +44,8 @@ theia-cloud:
 
   service:
     image: ghcr.io/ls1intum/theia/service:latest
+    # Public token (must match app.id or be set explicitly)
+    authToken: nJV3nKZmpxTD4wu2 
 
   preloading:
     images:


### PR DESCRIPTION
Add service.authToken variable (same as app id) that's expected by the latest version of theia-cloud which I'm syncing our fork to currently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added authentication token configuration option for the theia-cloud service, enabling users to explicitly set an authentication token during deployment for service identification and security purposes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->