### PR TITLE
Add average session memory usage board per appdefinition

### DIFF
--- a/charts/theia-monitoring/templates/dashboard-theiacloud.yaml
+++ b/charts/theia-monitoring/templates/dashboard-theiacloud.yaml
@@ -1077,11 +1077,7 @@ data:
       "templating": {
         "list": [
           {
-            "current": {
-              "selected": false,
-              "text": "test1",
-              "value": "test1"
-            },
+            "current": { "selected": false, "text": "theia", "value": "theia" },
             "hide": 0,
             "includeAll": false,
             "label": "Namespace",
@@ -1120,10 +1116,8 @@ data:
           }
         ]
       },
-      "time": {
-        "from": "now-15m",
-        "to": "now"
-      },
+      "time": { "from": "now-3h", "to": "now" },
+      "timeRangeUpdatedDuringEditOrView": false,
       "timepicker": {},
       "timezone": "browser",
       "title": "Theia Cloud",


### PR DESCRIPTION
Closes #36

- Add average cpu and memory charts grouped by appdefinition (and namespace)
- Correctly display metrics for prewarmed containers (different naming)
- Fixed cpu chart per container chart to use correct core metric (values are higher now)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new monitoring panels for Theia Session Backend memory and CPU usage metrics
  * Introduced Theia Cloud CPU and memory usage tracking visualizations
  * Added Theia Cluster metrics monitoring panels
  * Enhanced metrics filtering for improved data collection accuracy and relevance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->