### PR TITLE
Include the full project directory in persisted files, instead of jus…

### DIFF
--- a/charts/theia-appdefinitions/templates/appdefinition.yaml
+++ b/charts/theia-appdefinitions/templates/appdefinition.yaml
@@ -27,7 +27,7 @@ spec:
   imagePullPolicy: {{ .imagePullPolicy | default "IfNotPresent" }}
   downlinkLimit: {{ .downlinkLimit | default 30000 }}
   uplinkLimit: {{ .uplinkLimit | default 30000 }}
-  mountPath: {{ .mountPath | default "/home/project/persisted" }}
+  mountPath: {{ .mountPath | default "/home/project" }}
   timeout: {{ .timeout | default 1440 }}
   monitor:
     port: {{ (.monitor).port | default 3000 }}


### PR DESCRIPTION
# Fix session persistence

This is linked to a series of fixes as part of https://github.com/ls1intum/theia-cloud/issues/49.

In practice we faced container restarts due to exceeding memory limits. Easily reproducible with a small script. The restart lead to ephemeral parts of the filesystem being wiped after the restart. This meant essentially all workspace files being wiped as only the /home/project/persisted directory was, well, persisted. There wasn't any incentive/ configuration to use this directory though, hence no one did it.

The workspace persistent file feature worked all the time, but was just configured to an incorrect/ useless location.
This PR fixes this issue by persisting the whole project directory, leading to the expected experience.

**Important assumptions**: The ToolDockerfiles have to specify the workdir to be /home/project, or the override in individual appdefinitions has to be used for the feature to work correctly.

Everything outside of /home/project won't be persisted still, including things like configurations, etc. I think that's fine for now as most people won't reconfigure anything/ will face problems anyway due to insufficient permission to even change those files.