### PR TITLE
Remove specific hash pinning for staging env

### DIFF
--- a/deployments/theia-staging.artemis.cit.tum.de/values.yaml
+++ b/deployments/theia-staging.artemis.cit.tum.de/values.yaml
@@ -62,17 +62,17 @@ theia-cloud:
   # Index 11 is oauth2-proxy (distroless); the workflow does not override it.
   preloading:
     images:
-      - ghcr.io/eduide/eduidec-landing-page:latest-1483427
-      - ghcr.io/eduide/eduide/java-17:latest-0c8eec9
-      - ghcr.io/eduide/eduide/c:latest-0c8eec9
-      - ghcr.io/eduide/eduide/javascript:latest-0c8eec9
-      - ghcr.io/eduide/eduide/ocaml:latest-0c8eec9
-      - ghcr.io/eduide/eduide/rust:latest-0c8eec9
-      - ghcr.io/eduide/eduide/python:latest-0c8eec9
-      - ghcr.io/eduide/eduide/java-17-no-ls:latest-0c8eec9
-      - ghcr.io/eduide/eduide/rust-no-ls:latest-0c8eec9
-      - ghcr.io/eduide/eduide/langserver-java:latest-0c8eec9
-      - ghcr.io/eduide/eduide/langserver-rust:latest-0c8eec9
+      - ghcr.io/eduide/eduidec-landing-page:latest
+      - ghcr.io/eduide/eduide/java-17:latest
+      - ghcr.io/eduide/eduide/c:latest
+      - ghcr.io/eduide/eduide/javascript:latest
+      - ghcr.io/eduide/eduide/ocaml:latest
+      - ghcr.io/eduide/eduide/rust:latest
+      - ghcr.io/eduide/eduide/python:latest
+      - ghcr.io/eduide/eduide/java-17-no-ls:latest
+      - ghcr.io/eduide/eduide/rust-no-ls:latest
+      - ghcr.io/eduide/eduide/langserver-java:latest
+      - ghcr.io/eduide/eduide/langserver-rust:latest
       - image: quay.io/oauth2-proxy/oauth2-proxy:v7.12.0
         args: ["--version"]
 
@@ -84,7 +84,7 @@ theia-cloud:
 
   landingPage:
     # We use the try now page as landing page since the default does not support mutliple apps -> https://github.com/eclipsesource/theia-cloud/discussions/301
-    image: ghcr.io/eduide/eduidec-landing-page:latest-1483427
+    image: ghcr.io/eduide/eduidec-landing-page:latest
     sentry:
       enable: true
     logoFileExtension: "png"
@@ -136,7 +136,7 @@ theia-cloud:
     clientId: "theia-staging"
 
 theia-appdefinitions:
-  defaultImageTag: latest-0c8eec9
+  defaultImageTag: latest
 
 monitoring:
   targetNamespaces:

--- a/deployments/theia.artemis.cit.tum.de/values.yaml
+++ b/deployments/theia.artemis.cit.tum.de/values.yaml
@@ -62,7 +62,7 @@ theia-cloud:
   # Index 11 is oauth2-proxy (distroless); the workflow does not override it.
   preloading:
     images:
-      - ghcr.io/eduide/eduidec-landing-page:latest-1483427
+      - ghcr.io/eduide/eduidec-landing-page:latest-5761ebd
       - ghcr.io/eduide/eduide/java-17:latest-0c8eec9
       - ghcr.io/eduide/eduide/c:latest-0c8eec9
       - ghcr.io/eduide/eduide/javascript:latest-0c8eec9


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging environment image configurations to use latest tags instead of pinned versions for consistency across landing page, IDE services, language server components, and default application image tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->