### PR TITLE
Harden shared gateway certificate and route handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Configuration files for each environment are located in the [deployments/](deplo
    ```bash
    # Install Envoy Gateway and Gateway API CRDs according to your cluster provider.
    # Ensure the GatewayClass name matches `theia-cloud.gateway.className` (default: "envoy").
+   # If cert-manager will solve HTTP-01 challenges through Gateway API, enable:
+   #   --set config.enableGatewayAPI=true
    ```
 
 2. **Install Theia Cloud base charts**:

--- a/charts/theia-certificates/templates/admin-api-token-secret.yaml
+++ b/charts/theia-certificates/templates/admin-api-token-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.adminApiTokenSecret.enabled }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -5,3 +6,4 @@ metadata:
   name: {{ .Values.adminApiTokenSecret.name }}
 data:
   {{ .Values.adminApiTokenSecret.key }}: "{{ .Values.adminApiToken }}"
+{{- end }}

--- a/charts/theia-certificates/templates/instance-certificate.yml
+++ b/charts/theia-certificates/templates/instance-certificate.yml
@@ -1,3 +1,4 @@
+{{- if .Values.certificates.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -5,10 +6,11 @@ metadata:
 spec:
   secretName: ws-cert-secret
   issuerRef:
-    name: letsencrypt-prod
-    kind: ClusterIssuer
+    name: {{ .Values.certificates.issuerRef.name }}
+    kind: {{ .Values.certificates.issuerRef.kind }}
   commonName: "{{ .Values.hosts.configuration.instance }}.{{ .Values.hosts.configuration.baseHost }}"
   dnsNames:
     - "{{ .Values.hosts.configuration.instance }}.{{ .Values.hosts.configuration.baseHost }}"
   privateKey:
     rotationPolicy: Never
+{{- end }}

--- a/charts/theia-certificates/templates/landing-certificate.yml
+++ b/charts/theia-certificates/templates/landing-certificate.yml
@@ -1,3 +1,4 @@
+{{- if .Values.certificates.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -5,10 +6,11 @@ metadata:
 spec:
   secretName: landing-page-cert-secret
   issuerRef:
-    name: letsencrypt-prod
-    kind: ClusterIssuer
+    name: {{ .Values.certificates.issuerRef.name }}
+    kind: {{ .Values.certificates.issuerRef.kind }}
   commonName: "{{ .Values.hosts.configuration.landing }}.{{ .Values.hosts.configuration.baseHost }}"
   dnsNames:
     - "{{ .Values.hosts.configuration.landing }}.{{ .Values.hosts.configuration.baseHost }}"
   privateKey:
     rotationPolicy: Never
+{{- end }}

--- a/charts/theia-certificates/templates/service-certificate.yml
+++ b/charts/theia-certificates/templates/service-certificate.yml
@@ -1,3 +1,4 @@
+{{- if .Values.certificates.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -5,10 +6,11 @@ metadata:
 spec:
   secretName: service-cert-secret
   issuerRef:
-    name: letsencrypt-prod
-    kind: ClusterIssuer
+    name: {{ .Values.certificates.issuerRef.name }}
+    kind: {{ .Values.certificates.issuerRef.kind }}
   commonName: "{{ .Values.hosts.configuration.service }}.{{ .Values.hosts.configuration.baseHost }}"
   dnsNames:
     - "{{ .Values.hosts.configuration.service }}.{{ .Values.hosts.configuration.baseHost }}"
   privateKey:
     rotationPolicy: Never
+{{- end }}

--- a/charts/theia-certificates/templates/wildcard-secret.yaml
+++ b/charts/theia-certificates/templates/wildcard-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.wildcardTLSSecret.enabled }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
@@ -6,3 +7,4 @@ metadata:
 data:
   tls.crt: "{{ .Values.wildcardCertificate }}"
   tls.key: "{{ .Values.wildcardKey }}"
+{{- end }}

--- a/charts/theia-certificates/values.yaml
+++ b/charts/theia-certificates/values.yaml
@@ -5,10 +5,20 @@ hosts:
     landing: theia
     instance: instance.theia
 
+certificates:
+  enabled: true
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+
+wildcardTLSSecret:
+  enabled: true
+
 wildcardCertificate: # The base64 encoded wildcard certificate
 wildcardKey: # The base64 encoded wildcard key
 adminApiToken: # The base64 encoded admin API token
 
 adminApiTokenSecret:
+  enabled: true
   name: service-admin-api-token
   key: ADMIN_API_TOKEN

--- a/charts/theia-certificates/values.yaml
+++ b/charts/theia-certificates/values.yaml
@@ -8,6 +8,9 @@ hosts:
 certificates:
   enabled: true
   issuerRef:
+    # Default for tenant-local certificate management.
+    # Shared-gateway environments disable these certificates and use the
+    # shared gateway chart's Gateway API issuer instead.
     name: letsencrypt-prod
     kind: ClusterIssuer
 

--- a/charts/theia-cloud-combined/Chart.lock
+++ b/charts/theia-cloud-combined/Chart.lock
@@ -1,0 +1,18 @@
+dependencies:
+- name: theia-cloud
+  repository: oci://ghcr.io/eduide/charts
+  version: 1.4.0-next.4
+- name: theia-certificates
+  repository: file://../theia-certificates
+  version: 0.1.0
+- name: theia-appdefinitions
+  repository: file://../theia-appdefinitions
+  version: 0.1.0
+- name: theia-workspace-garbage-collector
+  repository: oci://ghcr.io/eduide/charts
+  version: 0.1.0
+- name: theia-shared-cache
+  repository: oci://ghcr.io/eduide/charts
+  version: 0.3.1
+digest: sha256:6e4a40b1d37da98b940d589f9857e05ffdefaa34409bb852340189d663e33b83
+generated: "2026-04-20T12:19:26.108265+02:00"

--- a/charts/theia-cloud-combined/values.yaml
+++ b/charts/theia-cloud-combined/values.yaml
@@ -9,7 +9,15 @@ hosts:
 theia-certificates:
   hosts:
     configuration: *hostsConfig
+  certificates:
+    enabled: true
+    issuerRef:
+      name: letsencrypt-prod
+      kind: ClusterIssuer
+  wildcardTLSSecret:
+    enabled: true
   adminApiTokenSecret:
+    enabled: true
     name: service-admin-api-token
     key: ADMIN_API_TOKEN
 
@@ -32,6 +40,8 @@ theia-cloud:
       enabled: true
     className: envoy
     name: theia-cloud-gateway
+    # When reusing a shared Gateway, set sectionName on each parentRef to scope
+    # these routes to the environment's HTTPS listeners only.
     parentRefs: []
     instancesRouteName: "theia-cloud-demo-ws-route"
     instancesWildcardSecretNames: {"*.webview.": static-theia-cert}

--- a/charts/theia-cloud-combined/values.yaml
+++ b/charts/theia-cloud-combined/values.yaml
@@ -12,6 +12,9 @@ theia-certificates:
   certificates:
     enabled: true
     issuerRef:
+      # Default for tenant-local certificate management.
+      # Shared-gateway environments disable these certificates and use the
+      # shared gateway chart's Gateway API issuer instead.
       name: letsencrypt-prod
       kind: ClusterIssuer
   wildcardTLSSecret:

--- a/charts/theia-shared-gateway/README.md
+++ b/charts/theia-shared-gateway/README.md
@@ -22,6 +22,8 @@ For production cluster values, use `deployments/shared-gateway-prod/values.yaml`
 ## Notes
 
 - The shared gateway chart should own the TLS material referenced by its listeners.
+- For concrete host certificates on Envoy Gateway, enable `gatewayAcmeIssuer` and add `HTTP` listeners on port `80` so cert-manager can solve HTTP-01 challenges through Gateway API.
+- cert-manager must be installed with Gateway API support enabled (`config.enableGatewayAPI=true`) before using `gatewayAcmeIssuer`.
 - For production, use cert-manager `Certificate` resources for concrete hosts and create the wildcard webview secret in `gateway.namespace` from the deploy-time wildcard certificate/key.
 - Tenant charts should set:
   - `theia-cloud.gateway.create=false`

--- a/charts/theia-shared-gateway/templates/gateway-acme-issuer.yaml
+++ b/charts/theia-shared-gateway/templates/gateway-acme-issuer.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.gatewayAcmeIssuer.enabled }}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ .Values.gatewayAcmeIssuer.name }}
+spec:
+  acme:
+    server: {{ .Values.gatewayAcmeIssuer.server | quote }}
+    email: {{ required "gatewayAcmeIssuer.email must be set when gatewayAcmeIssuer.enabled=true" .Values.gatewayAcmeIssuer.email | quote }}
+    privateKeySecretRef:
+      name: {{ .Values.gatewayAcmeIssuer.privateKeySecretName | quote }}
+    solvers:
+    - http01:
+        gatewayHTTPRoute:
+          serviceType: {{ .Values.gatewayAcmeIssuer.serviceType | quote }}
+          parentRefs:
+          - group: gateway.networking.k8s.io
+            kind: Gateway
+            name: {{ .Values.gateway.name }}
+            namespace: {{ .Values.gateway.namespace }}
+{{- end }}

--- a/charts/theia-shared-gateway/templates/gateway.yaml
+++ b/charts/theia-shared-gateway/templates/gateway.yaml
@@ -23,15 +23,21 @@ spec:
   {{- end }}
   listeners:
   {{- range $listener := .Values.gateway.listeners }}
+  {{- $protocol := default "HTTPS" $listener.protocol }}
+  {{- $port := default (ternary 443 80 (eq $protocol "HTTPS")) $listener.port }}
   - name: {{ $listener.name }}
-    protocol: HTTPS
-    port: 443
+    protocol: {{ $protocol }}
+    port: {{ $port }}
+    {{- with $listener.hostname }}
     hostname: {{ $listener.hostname | quote }}
+    {{- end }}
+    {{- if eq $protocol "HTTPS" }}
     tls:
       mode: Terminate
       certificateRefs:
       - kind: Secret
         name: {{ $listener.tlsSecretName | quote }}
+    {{- end }}
     allowedRoutes:
 {{ toYaml (default $.Values.gateway.allowedRoutes $listener.allowedRoutes) | nindent 6 }}
   {{- end }}

--- a/charts/theia-shared-gateway/values.yaml
+++ b/charts/theia-shared-gateway/values.yaml
@@ -16,8 +16,10 @@ gateway:
 
   # Each listener needs:
   # - name
+  # - protocol (`HTTPS` by default, `HTTP` for ACME challenge listeners)
+  # - port (defaults to 443 for HTTPS, 80 for HTTP)
   # - hostname
-  # - tlsSecretName
+  # - tlsSecretName (required for HTTPS listeners)
   listeners: []
 
 gatewayClass:
@@ -41,6 +43,14 @@ managedCertificates:
     kind: ClusterIssuer
     name: letsencrypt-prod
   certificates: []
+
+gatewayAcmeIssuer:
+  enabled: false
+  name: letsencrypt-prod-gateway
+  email: ""
+  privateKeySecretName: letsencrypt-prod-gateway-priv-key
+  server: https://acme-v02.api.letsencrypt.org/directory
+  serviceType: ClusterIP
 
 wildcardTLSSecret:
   create: false

--- a/deployments/shared-gateway-prod/values.yaml
+++ b/deployments/shared-gateway-prod/values.yaml
@@ -9,17 +9,37 @@ gateway:
 
   listeners:
     - name: prod-landing
+      protocol: HTTPS
+      port: 443
       hostname: theia.artemis.cit.tum.de
       tlsSecretName: landing-page-cert-secret
     - name: prod-service
+      protocol: HTTPS
+      port: 443
       hostname: service.theia.artemis.cit.tum.de
       tlsSecretName: service-cert-secret
     - name: prod-instances
+      protocol: HTTPS
+      port: 443
       hostname: instance.theia.artemis.cit.tum.de
       tlsSecretName: ws-cert-secret
     - name: prod-webview
+      protocol: HTTPS
+      port: 443
       hostname: "*.webview.instance.theia.artemis.cit.tum.de"
       tlsSecretName: static-theia-cert
+    - name: acme-landing-http
+      protocol: HTTP
+      port: 80
+      hostname: theia.artemis.cit.tum.de
+    - name: acme-service-http
+      protocol: HTTP
+      port: 80
+      hostname: service.theia.artemis.cit.tum.de
+    - name: acme-instance-http
+      protocol: HTTP
+      port: 80
+      hostname: instance.theia.artemis.cit.tum.de
 
 gatewayClass:
   create: true
@@ -47,7 +67,7 @@ managedCertificates:
   enabled: true
   issuerRef:
     kind: ClusterIssuer
-    name: letsencrypt-prod
+    name: letsencrypt-prod-gateway
   certificates:
     - name: landing-page-cert
       secretName: landing-page-cert-secret
@@ -58,6 +78,11 @@ managedCertificates:
     - name: instance-cert
       secretName: ws-cert-secret
       hostname: instance.theia.artemis.cit.tum.de
+
+gatewayAcmeIssuer:
+  enabled: true
+  name: letsencrypt-prod-gateway
+  email: ls1.itg@in.tum.de
 
 wildcardTLSSecret:
   create: true

--- a/deployments/test1.theia-test.artemis.cit.tum.de/values.yaml
+++ b/deployments/test1.theia-test.artemis.cit.tum.de/values.yaml
@@ -9,6 +9,12 @@ hosts:
 theia-certificates:
   hosts:
     configuration: *hostsConfig
+  certificates:
+    enabled: false
+  wildcardTLSSecret:
+    enabled: false
+  adminApiTokenSecret:
+    enabled: true
 
 theia-cloud:
   app:
@@ -32,8 +38,17 @@ theia-cloud:
     parentRefs:
       - name: theia-shared-gateway
         namespace: gateway-system
+        sectionName: test1-landing
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: test1-service
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: test1-instances
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: test1-webview
     instancesRouteName: "theia-cloud-demo-ws-route"
-    instancesWildcardSecretNames: { "*.webview.": static-theia-cert }
     serviceRouteRequestTimeout: "60s"
 
   monitor:

--- a/deployments/test2.theia-test.artemis.cit.tum.de/values.yaml
+++ b/deployments/test2.theia-test.artemis.cit.tum.de/values.yaml
@@ -9,6 +9,12 @@ hosts:
 theia-certificates:
   hosts:
     configuration: *hostsConfig
+  certificates:
+    enabled: false
+  wildcardTLSSecret:
+    enabled: false
+  adminApiTokenSecret:
+    enabled: true
 
 theia-cloud:
   app:
@@ -32,8 +38,17 @@ theia-cloud:
     parentRefs:
       - name: theia-shared-gateway
         namespace: gateway-system
+        sectionName: test2-landing
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: test2-service
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: test2-instances
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: test2-webview
     instancesRouteName: "theia-cloud-demo-ws-route"
-    instancesWildcardSecretNames: { "*.webview.": static-theia-cert }
     serviceRouteRequestTimeout: "60s"
 
   monitor:

--- a/deployments/test3.theia-test.artemis.cit.tum.de/values.yaml
+++ b/deployments/test3.theia-test.artemis.cit.tum.de/values.yaml
@@ -9,6 +9,12 @@ hosts:
 theia-certificates:
   hosts:
     configuration: *hostsConfig
+  certificates:
+    enabled: false
+  wildcardTLSSecret:
+    enabled: false
+  adminApiTokenSecret:
+    enabled: true
 
 theia-cloud:
   app:
@@ -32,8 +38,17 @@ theia-cloud:
     parentRefs:
       - name: theia-shared-gateway
         namespace: gateway-system
+        sectionName: test3-landing
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: test3-service
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: test3-instances
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: test3-webview
     instancesRouteName: "theia-cloud-demo-ws-route"
-    instancesWildcardSecretNames: { "*.webview.": static-theia-cert }
     serviceRouteRequestTimeout: "60s"
 
   monitor:

--- a/deployments/theia-staging.artemis.cit.tum.de/values.yaml
+++ b/deployments/theia-staging.artemis.cit.tum.de/values.yaml
@@ -9,6 +9,12 @@ hosts:
 theia-certificates:
   hosts:
     configuration: *hostsConfig
+  certificates:
+    enabled: false
+  wildcardTLSSecret:
+    enabled: false
+  adminApiTokenSecret:
+    enabled: true
 
 theia-cloud:
   app:
@@ -32,7 +38,16 @@ theia-cloud:
     parentRefs:
       - name: theia-shared-gateway
         namespace: gateway-system
-    instancesWildcardSecretNames: { "*.webview.": static-theia-cert }
+        sectionName: staging-landing
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: staging-service
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: staging-instances
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: staging-webview
     serviceRouteRequestTimeout: "60s"
 
   monitor:

--- a/deployments/theia.artemis.cit.tum.de/values.yaml
+++ b/deployments/theia.artemis.cit.tum.de/values.yaml
@@ -9,6 +9,12 @@ hosts:
 theia-certificates:
   hosts:
     configuration: *hostsConfig
+  certificates:
+    enabled: false
+  wildcardTLSSecret:
+    enabled: false
+  adminApiTokenSecret:
+    enabled: true
 
 theia-cloud:
   app:
@@ -32,7 +38,16 @@ theia-cloud:
     parentRefs:
       - name: theia-shared-gateway
         namespace: gateway-system
-    instancesWildcardSecretNames: { "*.webview.": static-theia-cert }
+        sectionName: prod-landing
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: prod-service
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: prod-instances
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: prod-webview
     serviceRouteRequestTimeout: "60s"
 
   monitor:

--- a/docs/adding-environments.md
+++ b/docs/adding-environments.md
@@ -61,7 +61,7 @@ hosts:
 
 - `theia-cloud.app.name` - Change to reflect the new environment (e.g., "Artemis Online IDE (Test2)")
 - `landingPage.infoTitle` - Update the environment name in the title
-- `theia-cloud.gateway.parentRefs` - Keep this pointing to the shared gateway (`theia-shared-gateway` in `gateway-system`)
+- `theia-cloud.gateway.parentRefs` - Keep this pointing to the shared gateway (`theia-shared-gateway` in `gateway-system`) and scope it to the environment's HTTPS listeners with `sectionName`
 
 For shared-gateway deployments, tenant namespaces should not create their own gateway:
 
@@ -75,10 +75,38 @@ theia-cloud:
     parentRefs:
       - name: theia-shared-gateway
         namespace: gateway-system
+        sectionName: <env>-landing
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: <env>-service
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: <env>-instances
+      - name: theia-shared-gateway
+        namespace: gateway-system
+        sectionName: <env>-webview
 ```
 
 Also update the shared Gateway listeners in `deployments/shared-gateway/values.yaml` (or `deployments/shared-gateway-prod/values.yaml` for production clusters).  
 For each new environment, add listener hostnames for landing, service, instances, and `*.webview.instance...`; otherwise Gateway API routes will not attach for that hostname.
+The listener names in the shared gateway must match the `sectionName` values above.
+If the shared gateway owns concrete host certificates through cert-manager, also add matching `HTTP` port `80` listeners so ACME HTTP-01 challenges can be routed through Gateway API.
+
+For shared-gateway deployments, disable the tenant-local certificate resources in `values.yaml` so the release does not recreate legacy namespace-local `Certificate` objects or wildcard TLS secrets:
+
+```yaml
+theia-certificates:
+  certificates:
+    enabled: false
+  wildcardTLSSecret:
+    enabled: false
+  adminApiTokenSecret:
+    enabled: true
+```
+
+Do not set `theia-cloud.gateway.instancesWildcardSecretNames` in these tenant values when `gateway.create: false`.
+That mapping is only used when the tenant release renders its own `Gateway`.
+In the shared-gateway setup, the wildcard TLS secret is owned only by the shared gateway release in `gateway-system`.
 
 #### Update `theia-base-helm-values.yml`
 

--- a/docs/tum-certificates.md
+++ b/docs/tum-certificates.md
@@ -4,9 +4,9 @@ This guide explains the TUM-specific process for obtaining and configuring wildc
 
 ## Overview
 
-Theia Cloud creates dynamic URIs for each session-plugin combination, requiring wildcard SSL certificates. At TUM, certificates are externally signed by RBG and have specific requirements:
+Theia Cloud creates dynamic URIs for each session-plugin combination, requiring wildcard SSL certificates. At TUM, those wildcard certificates are externally signed by RBG and have specific requirements:
 
-- Certificates cannot be automatically renewed via cert-manager
+- Wildcard certificates cannot be automatically renewed via cert-manager
 - Certificates must be requested through a specific approval process
 - Certificates are issued by Harica (TUM's certificate authority)
 


### PR DESCRIPTION
# Harden Shared Gateway Certificate And Route Handling

## Summary

This PR fixes the shared Gateway certificate renewal path and tightens route attachment so tenant traffic is no longer reachable over the temporary ACME HTTP listeners.

The main issue was that the shared Gateway certificates were still tied to the old ingress-nginx based HTTP-01 flow, while the cluster is now using Envoy Gateway and Gateway API. In addition, tenant `HTTPRoute`s attached to the whole shared Gateway instead of only the intended HTTPS listeners.

## What Changed

### Shared gateway ACME flow

- added Gateway API based ACME issuer rendering to the shared gateway chart
- extended shared gateway listeners to support explicit `protocol` and `port`
- added dedicated HTTP port `80` listeners for ACME HTTP-01 validation in prod
- switched the shared managed certificates to the Gateway API ACME issuer
- documented the cert-manager requirement for `config.enableGatewayAPI=true`

### Tenant certificate cleanup

- made the `theia-certificates` subchart resources configurable via enable flags
- disabled tenant-local `Certificate` resources and wildcard TLS secret creation for shared-gateway environments
- kept the tenant admin API token secret creation in place
- removed stale shared-gateway tenant value mappings that implied tenant ownership of the wildcard TLS secret

### Route hardening

- scoped shared-gateway tenant `parentRefs` to explicit HTTPS listeners via `sectionName`
- applied the listener mapping pattern to prod, staging, and test environment values
- documented that shared-gateway environments must align `sectionName` values with listener names

### Docs and chart maintenance

- updated shared gateway and environment setup documentation
- refreshed chart dependency lock data for `theia-cloud-combined`

## Why

- certificate renewal should work without ingress-nginx
- the only remaining HTTP listeners should be the ACME solver entry points
- tenant applications should not attach to port `80`
- wildcard TLS ownership should be unambiguous: the shared gateway release owns it in `gateway-system`

## Validation

### Render validation

- verified tenant releases render no local `Certificate` resources or wildcard TLS secret in shared-gateway environments
- verified tenant `HTTPRoute`s render `sectionName` values for the expected shared HTTPS listeners

### Cluster validation

- renewed shared Gateway certificates successfully through the Gateway API ACME flow
- confirmed there are no remaining `Ingress` resources in the cluster
- removed the legacy `letsencrypt-prod` issuer after confirming there were no remaining references

### External behavior

- `https://theia.artemis.cit.tum.de/` returns `200`
- `http://theia.artemis.cit.tum.de/` returns `404`
- `http://service.theia.artemis.cit.tum.de/` returns `404`
- `http://instance.theia.artemis.cit.tum.de/` returns `404`

## Notes

- the wildcard TLS secret is still required, but only in the shared gateway release in `gateway-system`
- this PR only covers `theia-deployment`; the separate `Docs` repository was left out of this branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway ACME issuer option for cert-manager with HTTP-01 support and configurable issuer selection.
  * Per-deployment toggles to enable/disable certificate provisioning, wildcard TLS secret, and admin API token secret.
  * HTTP listener additions for ACME challenge routing; listener protocol/port now honor explicit or sensible defaults and hostname is optional.

* **Documentation**
  * Added cluster prep note about cert-manager Gateway API.
  * Clarified shared-gateway listener, routing, and wildcard renewal guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->