### PR TITLE
fix java 17 templates image url

### DIFF
--- a/.github/workflows/deploy-theia.yml
+++ b/.github/workflows/deploy-theia.yml
@@ -380,21 +380,22 @@ jobs:
           fi
 
           # Only override IDE images when a tag is explicitly provided.
-          # Indices 0 (landing) and 1-10 (IDE + no-ls + langserver preload) are set above / here.
-          # Index 11 is oauth2-proxy (distroless); keep it only in values.yaml so it is never replaced by a string override.
+          # Indices 0 (landing) and 1-11 (IDE + no-ls + langserver preload) are set above / here.
+          # Index 12 is oauth2-proxy (distroless); keep it only in values.yaml so it is never replaced by a string override.
           if [ -n "${IDE_IMAGES_TAG}" ]; then
             HELM_CMD+=(
               --set "theia-cloud.preloading.images[1]=ghcr.io/eduide/eduide/java-17:${IDE_IMAGES_TAG}"
-              --set "theia-cloud.preloading.images[2]=ghcr.io/eduide/eduide/c:${IDE_IMAGES_TAG}"
-              --set "theia-cloud.preloading.images[3]=ghcr.io/eduide/eduide/javascript:${IDE_IMAGES_TAG}"
-              --set "theia-cloud.preloading.images[4]=ghcr.io/eduide/eduide/ocaml:${IDE_IMAGES_TAG}"
-              --set "theia-cloud.preloading.images[5]=ghcr.io/eduide/eduide/rust:${IDE_IMAGES_TAG}"
-              --set "theia-cloud.preloading.images[6]=ghcr.io/eduide/eduide/python:${IDE_IMAGES_TAG}"
+              --set "theia-cloud.preloading.images[2]=ghcr.io/eduide/eduide/java-17-templates:${IDE_IMAGES_TAG}"
+              --set "theia-cloud.preloading.images[3]=ghcr.io/eduide/eduide/c:${IDE_IMAGES_TAG}"
+              --set "theia-cloud.preloading.images[4]=ghcr.io/eduide/eduide/javascript:${IDE_IMAGES_TAG}"
+              --set "theia-cloud.preloading.images[5]=ghcr.io/eduide/eduide/ocaml:${IDE_IMAGES_TAG}"
+              --set "theia-cloud.preloading.images[6]=ghcr.io/eduide/eduide/rust:${IDE_IMAGES_TAG}"
+              --set "theia-cloud.preloading.images[7]=ghcr.io/eduide/eduide/python:${IDE_IMAGES_TAG}"
               # Intentionally override no-ls + langserver preload images globally when IDE tag is overridden.
-              --set "theia-cloud.preloading.images[7]=ghcr.io/eduide/eduide/java-17-no-ls:${IDE_IMAGES_TAG}"
-              --set "theia-cloud.preloading.images[8]=ghcr.io/eduide/eduide/rust-no-ls:${IDE_IMAGES_TAG}"
-              --set "theia-cloud.preloading.images[9]=ghcr.io/eduide/eduide/langserver-java:${IDE_IMAGES_TAG}"
-              --set "theia-cloud.preloading.images[10]=ghcr.io/eduide/eduide/langserver-rust:${IDE_IMAGES_TAG}"
+              --set "theia-cloud.preloading.images[8]=ghcr.io/eduide/eduide/java-17-no-ls:${IDE_IMAGES_TAG}"
+              --set "theia-cloud.preloading.images[9]=ghcr.io/eduide/eduide/rust-no-ls:${IDE_IMAGES_TAG}"
+              --set "theia-cloud.preloading.images[10]=ghcr.io/eduide/eduide/langserver-java:${IDE_IMAGES_TAG}"
+              --set "theia-cloud.preloading.images[11]=ghcr.io/eduide/eduide/langserver-rust:${IDE_IMAGES_TAG}"
               --set theia-appdefinitions.defaultImageTag="${IDE_IMAGES_TAG}"
             )
           fi

--- a/charts/theia-cloud-combined/values.yaml
+++ b/charts/theia-cloud-combined/values.yaml
@@ -76,7 +76,7 @@ theia-cloud:
       name: service-admin-api-token
       key: ADMIN_API_TOKEN
 
-  # Preload indices 0–10 align with .github/workflows/deploy-theia.yml tag overrides; 11 = oauth2-proxy (not overridden there).
+  # Preload indices 0–11 align with .github/workflows/deploy-theia.yml tag overrides; 12 = oauth2-proxy (not overridden there).
   preloading:
     images:
       - ghcr.io/eduide/eduidec-landing-page:latest

--- a/deployments/test1.theia-test.artemis.cit.tum.de/values.yaml
+++ b/deployments/test1.theia-test.artemis.cit.tum.de/values.yaml
@@ -72,8 +72,8 @@ theia-cloud:
   #     name: service-admin-api-token
   #     key: ADMIN_API_TOKEN
 
-  # Preload list indices 0–10 must match deploy-theia.yml --set overrides when tags are passed.
-  # Index 11 is oauth2-proxy (distroless); the workflow does not override it.
+  # Preload list indices 0–11 must match deploy-theia.yml --set overrides when tags are passed.
+  # Index 12 is oauth2-proxy (distroless); the workflow does not override it.
   preloading:
     images:
       - ghcr.io/eduide/eduidec-landing-page:latest

--- a/deployments/test2.theia-test.artemis.cit.tum.de/values.yaml
+++ b/deployments/test2.theia-test.artemis.cit.tum.de/values.yaml
@@ -72,8 +72,8 @@ theia-cloud:
   #     name: service-admin-api-token
   #     key: ADMIN_API_TOKEN
 
-  # Preload list indices 0–10 must match deploy-theia.yml --set overrides when tags are passed.
-  # Index 11 is oauth2-proxy (distroless); the workflow does not override it.
+  # Preload list indices 0–11 must match deploy-theia.yml --set overrides when tags are passed.
+  # Index 12 is oauth2-proxy (distroless); the workflow does not override it.
   preloading:
     images:
       - ghcr.io/eduide/eduidec-landing-page:latest

--- a/deployments/test3.theia-test.artemis.cit.tum.de/values.yaml
+++ b/deployments/test3.theia-test.artemis.cit.tum.de/values.yaml
@@ -80,8 +80,8 @@ theia-cloud:
       name: service-admin-api-token
       key: ADMIN_API_TOKEN
 
-  # Preload list indices 0–10 must match deploy-theia.yml --set overrides when tags are passed.
-  # Index 11 is oauth2-proxy (distroless); the workflow does not override it.
+  # Preload list indices 0–11 must match deploy-theia.yml --set overrides when tags are passed.
+  # Index 12 is oauth2-proxy (distroless); the workflow does not override it.
   preloading:
     images:
       - ghcr.io/eduide/eduidec-landing-page:latest

--- a/deployments/theia-staging.artemis.cit.tum.de/values.yaml
+++ b/deployments/theia-staging.artemis.cit.tum.de/values.yaml
@@ -73,8 +73,8 @@ theia-cloud:
       name: service-admin-api-token
       key: ADMIN_API_TOKEN
 
-  # Preload list indices 0–10 must match deploy-theia.yml --set overrides when tags are passed.
-  # Index 11 is oauth2-proxy (distroless); the workflow does not override it.
+  # Preload list indices 0–11 must match deploy-theia.yml --set overrides when tags are passed.
+  # Index 12 is oauth2-proxy (distroless); the workflow does not override it.
   preloading:
     images:
       - ghcr.io/eduide/eduidec-landing-page:latest

--- a/deployments/theia-staging.artemis.cit.tum.de/values.yaml
+++ b/deployments/theia-staging.artemis.cit.tum.de/values.yaml
@@ -79,7 +79,7 @@ theia-cloud:
     images:
       - ghcr.io/eduide/eduidec-landing-page:latest
       - ghcr.io/eduide/eduide/java-17:latest
-      - ghcr.io/eduide/eduide/java-latest-17:latest
+      - ghcr.io/eduide/eduide/java-17-templates:latest
       - ghcr.io/eduide/eduide/c:latest
       - ghcr.io/eduide/eduide/javascript:latest
       - ghcr.io/eduide/eduide/ocaml:latest

--- a/deployments/theia.artemis.cit.tum.de/values.yaml
+++ b/deployments/theia.artemis.cit.tum.de/values.yaml
@@ -73,8 +73,8 @@ theia-cloud:
       name: service-admin-api-token
       key: ADMIN_API_TOKEN
 
-  # Preload list indices 0–10 must match deploy-theia.yml --set overrides when tags are passed.
-  # Index 11 is oauth2-proxy (distroless); the workflow does not override it.
+  # Preload list indices 0–11 must match deploy-theia.yml --set overrides when tags are passed.
+  # Index 12 is oauth2-proxy (distroless); the workflow does not override it.
   preloading:
     images:
       - ghcr.io/eduide/eduidec-landing-page:latest-c51d7c0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Java environment image in staging deployment configuration to use the latest available templates version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EduIDE/EduIDE-deployment/pull/104)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->