### PR TITLE
`Development`: Update Keycloak URLs

### DIFF
--- a/charts/theia-cloud-combined/values.yaml
+++ b/charts/theia-cloud-combined/values.yaml
@@ -152,7 +152,7 @@ theia-cloud:
     adminGroup: "/theia-cloud/admin"
 
     # -- Key cloak auth URL. Only has to be specified when enable: true
-    authUrl: "https://keycloak.ase.in.tum.de/"
+    authUrl: "https://keycloak.aet.cit.tum.de/"
 
     # -- The Keycloak Realm. Only has to be specified when enable: true
     realm: "Test"

--- a/deployments/test1.theia-test.artemis.cit.tum.de/values.yaml
+++ b/deployments/test1.theia-test.artemis.cit.tum.de/values.yaml
@@ -149,7 +149,7 @@ theia-cloud:
     enable: true
 
     # -- Key cloak auth URL. Only has to be specified when enable: true
-    authUrl: "https://keycloak.ase.in.tum.de/"
+    authUrl: "https://keycloak.aet.cit.tum.de/"
 
     # -- The Keycloak Realm. Only has to be specified when enable: true
     realm: "Test"

--- a/deployments/test2.theia-test.artemis.cit.tum.de/values.yaml
+++ b/deployments/test2.theia-test.artemis.cit.tum.de/values.yaml
@@ -149,7 +149,7 @@ theia-cloud:
     enable: true
 
     # -- Key cloak auth URL. Only has to be specified when enable: true
-    authUrl: "https://keycloak.ase.in.tum.de/"
+    authUrl: "https://keycloak.aet.cit.tum.de/"
 
     # -- The Keycloak Realm. Only has to be specified when enable: true
     realm: "Test"

--- a/deployments/test3.theia-test.artemis.cit.tum.de/values.yaml
+++ b/deployments/test3.theia-test.artemis.cit.tum.de/values.yaml
@@ -153,7 +153,7 @@ theia-cloud:
     enable: true
 
     # -- Key cloak auth URL. Only has to be specified when enable: true
-    authUrl: "https://keycloak.ase.in.tum.de/"
+    authUrl: "https://keycloak.aet.cit.tum.de/"
 
     # -- The Keycloak Realm. Only has to be specified when enable: true
     realm: "Test"

--- a/deployments/theia-staging.artemis.cit.tum.de/values.yaml
+++ b/deployments/theia-staging.artemis.cit.tum.de/values.yaml
@@ -151,7 +151,7 @@ theia-cloud:
     enable: true
 
     # -- Key cloak auth URL. Only has to be specified when enable: true
-    authUrl: "https://keycloak.ase.in.tum.de/"
+    authUrl: "https://keycloak.aet.cit.tum.de/"
 
     # -- The Keycloak Realm. Only has to be specified when enable: true
     realm: "Test"

--- a/deployments/theia.artemis.cit.tum.de/values.yaml
+++ b/deployments/theia.artemis.cit.tum.de/values.yaml
@@ -150,7 +150,7 @@ theia-cloud:
     enable: true
 
     # -- Key cloak auth URL. Only has to be specified when enable: true
-    authUrl: "https://keycloak.ase.in.tum.de/"
+    authUrl: "https://keycloak.aet.cit.tum.de/"
 
     # # -- The Keycloak Realm. Only has to be specified when enable: true
     realm: "tum"

--- a/value-reference-files/theia-cloud-helm-values.yml
+++ b/value-reference-files/theia-cloud-helm-values.yml
@@ -114,4 +114,4 @@ landingPage:
 keycloak:
   enable: true
   # -- Key cloak auth URL. Only has to be specified when enable: true
-  authUrl: "https://keycloak.ase.in.tum.de/"
+  authUrl: "https://keycloak.aet.cit.tum.de/"

--- a/value-reference-files/tum-theia-cloud-helm-test-values.yaml
+++ b/value-reference-files/tum-theia-cloud-helm-test-values.yaml
@@ -121,4 +121,4 @@ theia-cloud:
   keycloak:
     enable: true
     # -- Key cloak auth URL. Only has to be specified when enable: true
-    authUrl: "https://keycloak.ase.in.tum.de/"
+    authUrl: "https://keycloak.aet.cit.tum.de/"


### PR DESCRIPTION
As part of our continuous efforts to deliver an excellent user experience across all systems, we are taking the next step.

Passkeys offer significantly better usability while also raising the security bar — but they require login services to run on a consistent, well-established domain. Reflecting the domain name changes our research group has undergone over the years, we are now consolidating our login-related infrastructure accordingly.

With this update, our Keycloak authentication service moves from keycloak.ase.in.tum.de to keycloak.aet.cit.tum.de — improving security, observability, and laying the foundation for seamless passkey integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Keycloak authentication endpoint across all deployment environments to use a new server address. This configuration change ensures authentication services maintain secure and consistent access across development, test, staging, and production environments. All configuration updates have been applied automatically without requiring any user action or service restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->