### PR TITLE
Use stud ARC runner for deployments

### DIFF
--- a/.github/workflows/deploy-theia.yml
+++ b/.github/workflows/deploy-theia.yml
@@ -97,7 +97,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    runs-on: ${{ inputs.execution_mode == 'github-runners' && 'ubuntu-latest' || 'arc-buildkit-eduide-amd64' }}
+    runs-on: ${{ inputs.execution_mode == 'github-runners' && 'ubuntu-latest' || 'arc-buildkit-eduide-stud-amd64' }}
     # Link to GitHub Environment for secrets and protection rules
     environment: ${{ inputs.environment }}
 


### PR DESCRIPTION
## Summary\n- route self-hosted deployment jobs to the new EduIDE stud ARC runner label\n\n## Validation\n- git diff --check\n\n## Notes\n- This replaces the old generic arc-buildkit-eduide-amd64 label with arc-buildkit-eduide-stud-amd64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline infrastructure to dynamically select the appropriate execution environment based on the configured deployment mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->